### PR TITLE
Improve layout styling

### DIFF
--- a/TicketingSystem/src/App.css
+++ b/TicketingSystem/src/App.css
@@ -1,5 +1,5 @@
 .app {
-  max-width: 800px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 2rem;
   text-align: left;
@@ -7,15 +7,17 @@
 
 .event-list {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 1rem;
-  margin-bottom: 2rem;
+  margin: 0 auto 2rem;
+  max-width: 1200px;
 }
 
 .event-card {
   background-color: #f9f9f9;
   border-radius: 4px;
   overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
- adjust container to 1200px wide and center
- display events in a responsive 4-column grid
- add subtle box shadow to event cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68448949753c832c99c8c87aaadcef5c